### PR TITLE
fix(workflows): review pull request from forked repo

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -1,7 +1,7 @@
 name: '🧐 Gemini Pull Request Review'
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - 'opened'
   pull_request_review_comment:
@@ -36,7 +36,7 @@ jobs:
   review-pr:
     if: |-
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && github.event.action == 'opened') ||
+      (github.event_name == 'pull_request_target' && github.event.action == 'opened') ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
         contains(github.event.comment.body, '@gemini-cli /review') &&
         (
@@ -77,10 +77,10 @@ jobs:
           app-id: '${{ vars.APP_ID }}'
           private-key: '${{ secrets.APP_PRIVATE_KEY }}'
 
-      - name: 'Get PR details (pull_request & workflow_dispatch)'
+      - name: 'Get PR details (pull_request_target & workflow_dispatch)'
         id: 'get_pr'
         if: |-
-          ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+          ${{ github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch' }}
         env:
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           EVENT_NAME: '${{ github.event_name }}'


### PR DESCRIPTION
## Summary by Sourcery

Enable the Gemini PR review workflow to run on forked repositories by switching to the pull_request_target event and updating related conditions.

CI:
- Change workflow trigger from pull_request to pull_request_target
- Update job conditional checks to use pull_request_target
- Rename and adjust the PR details retrieval step to reflect the new event trigger